### PR TITLE
openapi-to-ghp: Bugfix

### DIFF
--- a/openapi-to-ghp/action.yml
+++ b/openapi-to-ghp/action.yml
@@ -136,9 +136,8 @@ runs:
           SRC=$(jq -r '.key' <<< "${ENTRY}")
           DST=$(jq -r '.value' <<< "${ENTRY}")
 
-          TARGETDIR=$(dirname "${{ runner.temp }}/${DST}")
-          mkdir -p "${TARGETDIR}"
-          cp "${SRC}" "${TARGETDIR}"
+          mkdir -p "$(dirname "${{ runner.temp }}/${DST}")"
+          cp "${SRC}" "${{ runner.temp }}/${DST}"
         done
 
         FILES=$(yq -r 'to_entries | ["src/**.ts"] + map(.value) | @json' <<'EOF'


### PR DESCRIPTION
파일이름 변경을 무시하는 문제 해결