### PR TITLE
Buf: Add buf breaking & buf generate

### DIFF
--- a/buf/README.md
+++ b/buf/README.md
@@ -6,7 +6,7 @@ buf
 >
 > ##### Roadmap
 > - [x] `buf lint`
-> - [ ] `buf break --against ...`
+> - [x] `buf break --against ...`
 > - [ ] `buf generate`
 
 This GitHub action reads the gRPC schema file in the repository and uses the
@@ -35,7 +35,7 @@ References
 --------
 ```yaml
 - uses: actions/checkout@v4
-- uses: portone-io/actions/openapi-to-ghp@main
+- uses: portone-io/actions/buf@main
   with:
     # Directory where the `*.proto` files reside.
     # (default: "./protobuf")

--- a/buf/README.md
+++ b/buf/README.md
@@ -1,14 +1,5 @@
 buf
 ========
-
-> [!NOTE]
-> `portone-io/actions/buf` is still in active development.
->
-> ##### Roadmap
-> - [x] `buf lint`
-> - [x] `buf break --against ...`
-> - [ ] `buf generate`
-
 This GitHub action reads the gRPC schema file in the repository and uses the
 [buf] to lint it.
 

--- a/buf/action.yml
+++ b/buf/action.yml
@@ -16,12 +16,17 @@ runs:
         version: 1.28.1
 
     - shell: bash
-      run:  |
-        cd '${{ inputs.input-directory }}'
-        # Run Buf lint
+      working-directory: ${{ inputs.input-directory }}
+      run: |
+        # Lint .proto codes
         buf lint
-        
-        # Run Buf breaking
-        # Compare with ${{ inputs.input-directory }}/*.proto on the origin/main branch
-        git fetch origin
+
+        # Check if `buf generate` works properly
+        buf generate --template '${{ github.action_path }}/buf.gen.yaml'
+        (cd ../generated && ls)
+
+        # Check if there's any breaking changes. It checks backword
+        # compatibility of '${{ inputs.input-directory }}/*.proto' againt
+        # origin/main branch
+        git fetch --depth=1 origin main
         buf breaking --against '../.git#branch=origin/main,subdir=${{ inputs.input-directory }}'

--- a/buf/action.yml
+++ b/buf/action.yml
@@ -15,10 +15,13 @@ runs:
       with:
         version: 1.28.1
 
-    # Run Buf lint
     - shell: bash
       run:  |
         cd '${{ inputs.input-directory }}'
+        # Run Buf lint
         buf lint
-        # TODO: buf break
-        # TODO: buf generate
+        
+        # Run Buf breaking
+        # Compare with ${{ inputs.input-directory }}/*.proto on the origin/main branch
+        git fetch origin
+        buf breaking --against '../.git#branch=origin/main,subdir=${{ inputs.input-directory }}'

--- a/buf/buf.gen.yaml
+++ b/buf/buf.gen.yaml
@@ -1,0 +1,14 @@
+version: v1
+managed:
+  enabled: true
+  go_package_prefix:
+    default: github.com/${{ github.repository }}/generated
+    except:
+      - buf.build/googleapis/googleapis
+plugins:
+  - plugin: buf.build/protocolbuffers/go:v1.28.1
+    out: ../generated
+    opt: paths=source_relative
+  - plugin: buf.build/grpc/go
+    out: ../generated
+    opt: paths=source_relative,require_unimplemented_servers=false


### PR DESCRIPTION
[Click to see rendered README.md](https://github.com/portone-io/actions/tree/buf/buf#readme)
1. [Add buf breaking](https://github.com/portone-io/actions/commit/4ce47d86ae18edecc4983b4ede7d944d63693031) 
- main 브랜치의 프로토 파일과 비교하여 발생한  breaking change가 있는지 검사합니다.
- buf breaking 규칙은 가장 엄격하면서 기본 설정인 `FILE`을 준수합니다.
2. [Add buf generate](https://github.com/portone-io/actions/commit/f1ceeb653a84c555a196d0151e0b028d0b9009c0) 
- portone-io/go에서 사용하는 인터페이스라면, buf generate를 실행합니다.

참고
- [main 브랜치와 비교했을 때, proto파일에 대해 하위 호환성이 깨지는 경우 CI 결과 ](https://github.com/portone-io/authentication-service-interface/actions/runs/7127763004/job/19408345382)
- [ buf generate까지 성공했을 때 CI 결과](https://github.com/portone-io/authentication-service-interface/actions/runs/7137861630/job/19440362373)

