### PR TITLE
buf-go: add authentication to go build

### DIFF
--- a/buf-go/action.yml
+++ b/buf-go/action.yml
@@ -29,8 +29,17 @@ runs:
         version: ${{ inputs.buf-version }}
 
     - shell: bash
+      env:
+        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       working-directory: ${{ inputs.input-directory }}
       run: |
+        # Add SSH Go Module Private Key
+        mkdir -p ~/.ssh
+        ssh-keyscan github.com >> ~/.ssh/known_hosts
+        ssh-agent -a $SSH_AUTH_SOCK > /dev/null	
+        ssh-add - <<< "${{ inputs.deploy-key }}"
+        echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $GITHUB_ENV
+        
         set -x
 
         # Run `buf generate`
@@ -54,7 +63,7 @@ runs:
           go mod init "github.com/portone-io/go/interface/${SLUG}"
           go work use .
           go mod tidy
-          git config --global 'url.https://${{ github.actor }}:${{ github.token }}@github.com/.insteadOf' https://github.com/
+          git config --global url."ssh://git@github.com/".insteadOf https://github.com/
           go env -w GOPRIVATE='github.com/portone-io/*'
           go build ./...
         )

--- a/buf-go/action.yml
+++ b/buf-go/action.yml
@@ -28,18 +28,13 @@ runs:
       with:
         version: ${{ inputs.buf-version }}
 
+    - uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: ${{ inputs.deploy-key }}
+
     - shell: bash
-      env:
-        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       working-directory: ${{ inputs.input-directory }}
       run: |
-        # Add SSH Go Module Private Key
-        mkdir -p ~/.ssh
-        ssh-keyscan github.com >> ~/.ssh/known_hosts
-        ssh-agent -a $SSH_AUTH_SOCK > /dev/null	
-        ssh-add - <<< "${{ inputs.deploy-key }}"
-        echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $GITHUB_ENV
-        
         set -x
 
         # Run `buf generate`

--- a/buf-go/action.yml
+++ b/buf-go/action.yml
@@ -54,6 +54,8 @@ runs:
           go mod init "github.com/portone-io/go/interface/${SLUG}"
           go work use .
           go mod tidy
+          git config --global 'url.https://${{ github.actor }}:${{ github.token }}@github.com/.insteadOf' https://github.com/
+          go env -w GOPRIVATE='github.com/portone-io/*'
           go build ./...
         )
 


### PR DESCRIPTION
### 작업 히스토리
[channel-service-interface tagging시 buf-go action이 go build 단계에서 실패](https://github.com/portone-io/channel-service-interface/actions/runs/8283290949/job/22666102084)

### 작업 내용
https://portone-io.slack.com/archives/C034ADZQMEX/p1710903860529759 참고

### 테스트 내용
buf-go action [정상 동작](https://github.com/portone-io/channel-service-interface/actions/runs/8353509590) 확인 완료