### PR TITLE
upgrade go version to 1.22

### DIFF
--- a/buf-go/action.yml
+++ b/buf-go/action.yml
@@ -59,7 +59,6 @@ runs:
         (
           cd "./interface/${SLUG}"
           go mod init "github.com/portone-io/go/interface/${SLUG}"
-          go work use .
           go mod tidy
           git config --global url."ssh://git@github.com/".insteadOf https://github.com/
           go env -w GOPRIVATE='github.com/portone-io/*'

--- a/buf-go/action.yml
+++ b/buf-go/action.yml
@@ -10,13 +10,16 @@ inputs:
   deploy-key:
     description: 'Deploy key (OpenSSH private key) which have write permission to portone-io/go repository'
     required: true
+  go-version:
+    description: 'The version of golang to use (default: "1.20")'
+    default: 1.20
 
 runs:
   using: composite
   steps:
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: ${{ inputs.go-version }}
 
     - uses: actions/checkout@v4
       with:

--- a/buf/action.yml
+++ b/buf/action.yml
@@ -7,13 +7,16 @@ inputs:
   buf-version:
     description: 'The version of the buf cli to use. (ex: "latest", "1.28.0", default: "1.28.1")'
     default: 1.28.1
+  go-version:
+    description: 'The version of golang to use (default: "1.20")'
+    default: 1.20
 
 runs:
   using: composite
   steps:
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: ${{ inputs.go-version }}
 
     - uses: bufbuild/buf-setup-action@v1
       with:


### PR DESCRIPTION
### 작업 한 내용
- proto 파일을 generate 할때 go 버전을 인풋 파라미터로 받고 기본 값을 1.20로 설정해 하위 호환성 유지하도록 조치
- [portone-io/go에서 더이상 go.work을 사용하지 않](https://github.com/portone-io/go/pull/227)기 때문에 portone-io/go의 main 브랜치에 push 하기 전 실행하던 `go work use .` 커맨드 삭제