### PR TITLE
fix: make go-version default a string

### DIFF
--- a/buf-go/action.yml
+++ b/buf-go/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: true
   go-version:
     description: 'The version of golang to use (default: "1.20")'
-    default: 1.20
+    default: '1.20'
 
 runs:
   using: composite

--- a/buf/action.yml
+++ b/buf/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: 1.28.1
   go-version:
     description: 'The version of golang to use (default: "1.20")'
-    default: 1.20
+    default: '1.20'
 
 runs:
   using: composite


### PR DESCRIPTION
YAML 문법에 따라 1.20이 1.2로 취급되던 오류를 고칩니다.