### PR TITLE
openapi-to-ghp: Add parameter for custom docker repository

### DIFF
--- a/openapi-to-ghp/action.yml
+++ b/openapi-to-ghp/action.yml
@@ -30,6 +30,14 @@ inputs:
   registry-url:
     description: 'URL of NPM registry to upload. (default: "https://npm.pkg.github.com")'
     default: https://npm.pkg.github.com
+  generator-docker-repository:
+    description: The Docker repository uses as source for openapitools/openapi-generator-cli image.
+    required: false
+    default: "docker.io"
+  generator-docker-image:
+    description: The Docker image used by the generator.
+    required: false
+    default: "openapitools/openapi-generator-cli"
   openapi-generator-version:
     description: 'The Docker tag of the openapitools/openapi-generator-cli image to use. See https://hub.docker.com/r/openapitools/openapi-generator-cli/tags for available tags. (ex: "latest", "v7.1.0", default: "v6.2.1")'
     default: v6.2.1
@@ -128,6 +136,8 @@ runs:
         generator: ${{ inputs.generator-type }}
         generator-tag: ${{ inputs.openapi-generator-version }}
         command-args: ${{ inputs.generator-cli-args }}
+        docker-repository: ${{ inputs.generator-docker-repository }}
+        docker-image: ${{ inputs.generator-docker-image }}
 
     # Package and publish codes
     - if: steps.check.outputs.result == 'do'


### PR DESCRIPTION
[Slack 논의](https://portone-io.slack.com/archives/C03N8773P1A/p1721032791054889)

일부 기능을 수정한 커스텀 제너레이터를 GitHub Container Registry에 publish 해서 사용하기 위해, [openapitools-generator-action](https://github.com/openapi-generators/openapitools-generator-action)의 `docker-repository`와 `docker-image` 옵션을 설정할 수 있는 파라미터를 추가했습니다.