### PR TITLE
openapi-to-ghp: Add parameter for custom axios version

### DIFF
--- a/openapi-to-ghp/action.yml
+++ b/openapi-to-ghp/action.yml
@@ -60,6 +60,10 @@ inputs:
 
       If left empty (default behavior), the action will proceed with the default package.json configuration without any custom overrides.
     default: '{}'
+  axios-version:
+    description: 'The axios version in package.json'
+    required: false
+    default: '^0.27.2'
 
 runs:
   using: composite
@@ -189,7 +193,7 @@ runs:
           },
           "files": ${FILES},
           "peerDependencies": {
-            "axios": "^0.27.2"
+            "axios": "${{ inputs.axios-version }}"
           }
         }
         EOF


### PR DESCRIPTION
openapi-generator의 [typescript-axios 제너레이터](https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/typescript-axios.md#config-options)가 axios 1.6.1 버전을 기준으로 코드를 생성하고 있는데, 현재 workflow에서는 0.27.2 버전을 고정으로 사용하고 있어서 사용자가 원하는 axios 버전을 지정할 수 있도록 파라미터를 추가했습니다.