### PR TITLE
feat: openapi 의 버전을 올리며 axios 의존성을 제거합니다

### DIFF
--- a/openapi-to-ghp/action.yml
+++ b/openapi-to-ghp/action.yml
@@ -43,7 +43,7 @@ inputs:
     default: v7.16.0
   generator-type:
     description: 'The generator you wish to use. See https://openapi-generator.tech/docs/generators/ for available generators. (ex: "javascript", "typescript-fetch", default: "typescript-axios")'
-    default: typescript-fetch
+    default: typescript
   generator-cli-args:
     description: 'Additional arguments to pass through to the generate command. (default: "--additional-properties paramNaming=original,supportsES6=true")'
     default: --additional-properties paramNaming=original,supportsES6=true

--- a/openapi-to-ghp/action.yml
+++ b/openapi-to-ghp/action.yml
@@ -1,5 +1,5 @@
 name: OpenAPI to GitHub Packages
-
+description: openapi to github packages
 inputs:
   input:
     description: 'Path of OpenAPI schema, YAML or JSON. (ex: "src/login_server.yaml", "auth_service.swagger.json")'
@@ -130,7 +130,7 @@ runs:
 
     # Generate codes from OpenAPI
     - if: steps.check.outputs.result == 'do'
-      uses: openapi-generators/openapitools-generator-action@v1.5.0
+      uses: openapi-generators/openapitools-generator-action@b729d184e6b3459572c37c0e37f88a832e69b552 #v1.5.0
       with:
         openapi-file: ${{ inputs.input }}
         generator: ${{ inputs.generator-type }}
@@ -141,9 +141,9 @@ runs:
 
     # Package and publish codes
     - if: steps.check.outputs.result == 'do'
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
       with:
-        node-version: '22.9'
+        node-version: '26.4'
         registry-url: ${{ inputs.registry-url }}
         scope: '@${{ inputs.scope }}'
     - if: steps.check.outputs.result == 'do'

--- a/openapi-to-ghp/action.yml
+++ b/openapi-to-ghp/action.yml
@@ -130,7 +130,7 @@ runs:
 
     # Generate codes from OpenAPI
     - if: steps.check.outputs.result == 'do'
-      uses: openapi-generators/openapitools-generator-action@v1
+      uses: openapi-generators/openapitools-generator-action@v1.5.0
       with:
         openapi-file: ${{ inputs.input }}
         generator: ${{ inputs.generator-type }}

--- a/openapi-to-ghp/action.yml
+++ b/openapi-to-ghp/action.yml
@@ -40,10 +40,10 @@ inputs:
     default: "openapitools/openapi-generator-cli"
   openapi-generator-version:
     description: 'The Docker tag of the openapitools/openapi-generator-cli image to use. See https://hub.docker.com/r/openapitools/openapi-generator-cli/tags for available tags. (ex: "latest", "v7.1.0", default: "v6.2.1")'
-    default: v6.2.1
+    default: v7.16.0
   generator-type:
     description: 'The generator you wish to use. See https://openapi-generator.tech/docs/generators/ for available generators. (ex: "javascript", "typescript-fetch", default: "typescript-axios")'
-    default: typescript-axios
+    default: typescript-fetch
   generator-cli-args:
     description: 'Additional arguments to pass through to the generate command. (default: "--additional-properties paramNaming=original,supportsES6=true")'
     default: --additional-properties paramNaming=original,supportsES6=true
@@ -60,10 +60,6 @@ inputs:
 
       If left empty (default behavior), the action will proceed with the default package.json configuration without any custom overrides.
     default: '{}'
-  axios-version:
-    description: 'The axios version in package.json'
-    required: false
-    default: '^0.27.2'
 
 runs:
   using: composite
@@ -170,7 +166,7 @@ runs:
           cp "${SRC}" "${{ runner.temp }}/${DST}"
         done
 
-        FILES=$(yq -r 'to_entries | ["src/**.ts"] + map(.value) | @json' <<'EOF'
+        FILES=$(yq -r 'to_entries | ["src/**/**.ts"] + map(.value) | @json' <<'EOF'
         ${{ inputs.additional-files }}
         EOF
         )
@@ -192,10 +188,7 @@ runs:
             "access": "restricted",
             "registry": "${{ inputs.registry-url}}"
           },
-          "files": ${FILES},
-          "peerDependencies": {
-            "axios": "${{ inputs.axios-version }}"
-          }
+          "files": ${FILES}
         }
         EOF
 


### PR DESCRIPTION
public-api-service 를 재외한 나머지 서비스들의 전환이 완료 되었을 경우 main에 반영예정입니다

Changes: 
- axios 의 peerDependencies 를 재거합니다
- typescript-axios 가 아닌 다른 제네래이터들은 하위 폴더가 있는 경우가 있어 이를 감지할 수 있도록 수정합니다.
- openapi-generator 의 기본버전을 올립니다.