### PR TITLE
chore: 취약점으로 인한 CI의 axios버전 업데이트

### DIFF
--- a/openapi-to-ghp/action.yml
+++ b/openapi-to-ghp/action.yml
@@ -63,7 +63,7 @@ inputs:
   axios-version:
     description: 'The axios version in package.json'
     required: false
-    default: '^0.27.2'
+    default: '^1.15.0'
 
 runs:
   using: composite


### PR DESCRIPTION
각 인터페이스 래포와 사용처에 호환성을 전부 확인후 병합예정입니다.
- 콘솔: https://github.com/portone-io/web/pull/5507