### PR TITLE
fix: openapi to ghs 태깅안되는 버그수정

### DIFF
--- a/openapi-to-ghp/action.yml
+++ b/openapi-to-ghp/action.yml
@@ -1,4 +1,5 @@
 name: OpenAPI to GitHub Packages
+description: OpenAPI to Github Packages in Portone
 
 inputs:
   input:
@@ -75,7 +76,7 @@ runs:
         case '${{ inputs.versioning }}' in
           file)
             echo "version=$(cat VERSION)" >> "${GITHUB_OUTPUT}"
-            echo 'publish-args=' >> "${GITHUB_OUTPUT}"
+            echo 'publish-args=--tag latest' >> "${GITHUB_OUTPUT}"
             ;;
 
           tag)
@@ -83,7 +84,7 @@ runs:
               exit 1
             fi
             echo "version=${GITHUB_REF#refs/tags/v}" >> "${GITHUB_OUTPUT}"
-            echo 'publish-args=' >> "${GITHUB_OUTPUT}"
+            echo 'publish-args=--tag beta' >> "${GITHUB_OUTPUT}"
             ;;
 
           canary)
@@ -93,7 +94,7 @@ runs:
 
           manual)
             echo 'version=${{ inputs.version }}' >> "${GITHUB_OUTPUT}"
-            echo 'publish-args=' >> "${GITHUB_OUTPUT}"
+            echo 'publish-args=--tag dev' >> "${GITHUB_OUTPUT}"
             ;;
 
           *)

--- a/openapi-to-ghp/action.yml
+++ b/openapi-to-ghp/action.yml
@@ -76,7 +76,7 @@ runs:
         case '${{ inputs.versioning }}' in
           file)
             echo "version=$(cat VERSION)" >> "${GITHUB_OUTPUT}"
-            echo 'publish-args=--tag latest' >> "${GITHUB_OUTPUT}"
+            echo 'publish-args=--tag beta' >> "${GITHUB_OUTPUT}"
             ;;
 
           tag)


### PR DESCRIPTION
> https://github.com/portone-io/public-api-service/actions/runs/29386364026/job/87260394365

--tag 적용이 안되어있어서 publish 가 무시되는 버그 수정합니다